### PR TITLE
Fix changed APT gpg key id to work with April 2020 change

### DIFF
--- a/manifests/repo/debian.pp
+++ b/manifests/repo/debian.pp
@@ -22,7 +22,7 @@ class jenkins::repo::debian
         'src' => false,
       },
       key      => {
-        'id'     => '150FDE3F7787E7D11EF4E12A9B7D32F2D50582E6',
+        'id'     => '62A9756BFD780C377CF24BA8FCEF32E745F2C3D5',
         'source' => "${pkg_host}/debian/jenkins-ci.org.key",
       },
       require  => Package['apt-transport-https'],
@@ -38,7 +38,7 @@ class jenkins::repo::debian
         'src' => false,
       },
       key      => {
-        'id'     => '150FDE3F7787E7D11EF4E12A9B7D32F2D50582E6',
+        'id'     => '62A9756BFD780C377CF24BA8FCEF32E745F2C3D5',
         'source' => "${pkg_host}/debian/jenkins-ci.org.key",
       },
       require  => Package['apt-transport-https'],


### PR DESCRIPTION
https://pkg.jenkins.io/debian/

> WARNING: The gpg key use to sign our packages has been updated on 16th of April 2020, therefore you need to reimport it if you imported before this date.

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
    Replace this comment with a description of your pull request.
-->

#### This Pull Request (PR) fixes the following issues
<!--
    Replace this comment with the list of issues or n/a.
    Use format:
    Fixes #123
    Fixes #124
-->
